### PR TITLE
Remove backend settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 ### powerful plotting library built on the popular Matplotlib
 
+> before running the library, it is necessary to configure the backend.
+> Details: https://matplotlib.org/users/customizing.html
+Examples: $cat ~/.matplotlib/matplotlibrc
+```
+backend: TkAgg
+```
+
 ![image](https://github.com/guenchi/Matplotlib/blob/master/img/Figure_1.png)
 
 ```

--- a/pyplot.sc
+++ b/pyplot.sc
@@ -1,17 +1,17 @@
 ;  MIT License
 
-;  Copyright guenchi (c) 2018 - 2019 
-         
+;  Copyright guenchi (c) 2018 - 2019
+
 ;  Permission is hereby granted, free of charge, to any person obtaining a copy
 ;  of this software and associated documentation files (the "Software"), to deal
 ;  in the Software without restriction, including without limitation the rights
 ;  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 ;  copies of the Software, and to permit persons to whom the Software is
 ;  furnished to do so, subject to the following conditions:
-         
+
 ;  The above copyright notice and this permission notice shall be included in all
 ;  copies or substantial portions of the Software.
-         
+
 ;  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 ;  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 ;  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -38,12 +38,10 @@
         (only (darkart py ffi) py/run-simple-string))
 
 
-    (define plt 
+    (define plt
         (begin
             (py/run-simple-string "import sys")
             (py/run-simple-string "sys.argv = ['']")
-            (py/run-simple-string "import matplotlib")
-            (py/run-simple-string "matplotlib.use('TkAgg')")
             (py-import 'matplotlib.pyplot)))
 
 


### PR DESCRIPTION
I am not sure of your working system. I had several problems with plotting the graph with `TkAgg`. It seems the problem related to these issues:
- https://matplotlib.org/faq/osx_framework.html 
- https://github.com/matplotlib/matplotlib/issues/12074

Finally, I ran the plotting successfully with Qt5 in a virtual environment. However, I didn't find the solution for the backend `MacOSX` and `TkAgg`.
